### PR TITLE
[id] allow timestamp options

### DIFF
--- a/packages/playground/static/config.yml
+++ b/packages/playground/static/config.yml
@@ -18,6 +18,7 @@ collections:
         name: id
         widget: ncw-id
         prefix: post
+        timestamp: true
         hint: This widget generate an unique read-only id
 
       - label: Categories

--- a/packages/widget-id/package.json
+++ b/packages/widget-id/package.json
@@ -16,6 +16,7 @@
     "prepublishOnly": "tsc -p ./"
   },
   "dependencies": {
+    "moment": "^2.24.0",
     "shortid": "^2.2.14"
   },
   "publishConfig": {

--- a/packages/widget-id/src/control.tsx
+++ b/packages/widget-id/src/control.tsx
@@ -3,9 +3,6 @@ import shortid from 'shortid'
 import { WidgetProps } from '@ncwidgets/common-typings'
 
 export class Control extends React.Component<WidgetProps> {
-  public state = {
-    id: ''
-  }
   public componentDidMount() {
     const {
       value,
@@ -15,20 +12,13 @@ export class Control extends React.Component<WidgetProps> {
     
     if (value) return
   
-    const prefix = field.get('prefix')
-    const id = `${prefix ? prefix + '-' : ''}${shortid()}`
-    this.setState({ id })
-    setTimeout(() => {
-      onChange(id)
-    }, 0)
-  }
+    const usePrefix = field.get('prefix')
+    const useTimestamp = field.get('timestamp')
 
-  public componentDidUpdate() {
-    const { value, onChange } = this.props
-    const { id } = this.state
-    if (value) {
-      return
-    }
+    const prefix = usePrefix ? usePrefix + '-' : ''
+    const timestamp = useTimestamp ? Date.now() + '-' : ''
+
+    const id = prefix + timestamp + shortid()
     onChange(id)
   }
 
@@ -40,7 +30,6 @@ export class Control extends React.Component<WidgetProps> {
       setInactiveStyle,
       value,
     } = this.props
-    const { id } = this.state
     return (
       <input
         type="text"
@@ -48,8 +37,7 @@ export class Control extends React.Component<WidgetProps> {
         style={{
           color: '#cdcdcd',
         }}
-        value={value || id}
-        // value={value}
+        value={value || ''}
         id={forID}
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}


### PR DESCRIPTION
In a folder collection, it makes sense to set `identifier_field` to value generated by `@ncwidgets/id`. However because of this the entries are sorted randomly. Allowing timestamp will at least let them be sorted by something that make sense.