### PR TITLE
[reorder] handle the case where display fields are out of date

### DIFF
--- a/packages/playground/index.js
+++ b/packages/playground/index.js
@@ -28,7 +28,7 @@ const CustomReorderPreview = ({ value }) => (
 )
 
 const CustomReorderControl = createControl({
-  renderListItem: item => <ListComponent item={item} />
+  renderListItem: ({ item }) => <ListComponent item={item} />
 })
 
 const CMS = () => {

--- a/packages/playground/index.js
+++ b/packages/playground/index.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { render } from 'react-dom'
 import cms from 'netlify-cms-app'
 import { Widget as IdWidget } from '@ncwidgets/id'
-import { Widget as ReorderWidget, createControl } from '@ncwidgets/reorder'
+import { Widget as ReorderWidget, createControl, usePreviewData } from '@ncwidgets/reorder'
 import { Widget as FileRelationWidget } from '@ncwidgets/file-relation'
 import repoData from './static/data'
 
@@ -19,13 +19,17 @@ const ListComponent = ({ item }) => (
   </>
 )
 
-const CustomReorderPreview = ({ value }) => (
-  <section>
-    <hr />
-    <p>Custom Widget Preview</p>
-    {value.map((item, i) => <p key={i}>{item.get('title')}</p>)}
-  </section>
-)
+const CustomReorderPreview = (props) => {
+  const data = usePreviewData(props)
+
+  if (!data) return <div>loading...</div>
+  return (
+    <section>
+      <hr />
+      <p>Custom Widget Preview</p>
+      {data.map((item, i) => <p key={i}>{item['title']}</p>)}
+    </section>
+  )}
 
 const CustomReorderControl = createControl({
   renderListItem: ({ item }) => <ListComponent item={item} />

--- a/packages/playground/static/config.yml
+++ b/packages/playground/static/config.yml
@@ -47,7 +47,7 @@ collections:
             widget: ncw-reorder
             collection: posts
             id_field: id
-            display_fields: ["title", "id"]
+            display_fields: ["title"]
             hint: "this reorder widget display entries from `posts` collection."
 
           - label: Featured Posts (Custom)

--- a/packages/playground/static/config.yml
+++ b/packages/playground/static/config.yml
@@ -55,7 +55,7 @@ collections:
             widget: custom-reorder
             collection: posts
             id_field: id
-            display_fields: ["title", "id"]
+            display_fields: ["title"]
             hint: "this is a reorder widget with custom control"
 
   - label: Setting

--- a/packages/playground/static/data.js
+++ b/packages/playground/static/data.js
@@ -16,16 +16,16 @@ const homeContent = {
   ],
   featured: [
     {
-      id: 'post-Rarn0He12',
-      title: '안녕 세상',
+      id: 'post-mfYTWoPYN',
+      // title: 'Hello World',
     },
     {
       id: 'post-Rarn0HeUo',
-      title: 'Hallo Welt',
+      // title: 'Hallo Welt',
     },
     {
-      id: 'post-mfYTWoPYN',
-      title: 'Hello World',
+      id: 'post-Rarn0He12',
+      // title: '안녕 세상',
     },
   ]
 }

--- a/packages/playground/static/data.js
+++ b/packages/playground/static/data.js
@@ -3,29 +3,23 @@ const homeContent = {
   featuredCustom: [
     {
       id: 'post-Rarn0He12',
-      title: '안녕 세상',
     },
     {
       id: 'post-Rarn0HeUo',
-      title: 'Hallo Welt',
     },
     {
       id: 'post-mfYTWoPYN',
-      title: 'Hello World',
     },
   ],
   featured: [
-    {
-      id: 'post-mfYTWoPYN',
-      // title: 'Hello World',
-    },
+    // {
+    //   id: 'post-Rarn0He12',
+    // },
     {
       id: 'post-Rarn0HeUo',
-      // title: 'Hallo Welt',
     },
     {
-      id: 'post-Rarn0He12',
-      // title: '안녕 세상',
+      id: 'post-mfYTWoPYN',
     },
   ]
 }

--- a/packages/playground/static/data.js
+++ b/packages/playground/static/data.js
@@ -12,15 +12,15 @@ const homeContent = {
     },
   ],
   featured: [
-    // {
-    //   id: 'post-Rarn0He12',
-    // },
-    // {
-    //   id: 'post-Rarn0HeUo',
-    // },
-    // {
-    //   id: 'post-mfYTWoPYN',
-    // },
+    {
+      id: 'post-Rarn0He12',
+    },
+    {
+      id: 'post-Rarn0HeUo',
+    },
+    {
+      id: 'post-mfYTWoPYN',
+    },
   ]
 }
 
@@ -72,14 +72,14 @@ export default {
     }
   },
   '_posts': {
-    // 'hello.md': {
-    //   'content': post1
-    // },
-    // 'hi.md': {
-    //   'content': post2
-    // },
-    // 'ha.md': {
-    //   'content': post3
-    // }
+    'hello.md': {
+      'content': post1
+    },
+    'hi.md': {
+      'content': post2
+    },
+    'ha.md': {
+      'content': post3
+    }
   }
 }

--- a/packages/playground/static/data.js
+++ b/packages/playground/static/data.js
@@ -15,12 +15,12 @@ const homeContent = {
     // {
     //   id: 'post-Rarn0He12',
     // },
-    {
-      id: 'post-Rarn0HeUo',
-    },
-    {
-      id: 'post-mfYTWoPYN',
-    },
+    // {
+    //   id: 'post-Rarn0HeUo',
+    // },
+    // {
+    //   id: 'post-mfYTWoPYN',
+    // },
   ]
 }
 
@@ -72,14 +72,14 @@ export default {
     }
   },
   '_posts': {
-    'hello.md': {
-      'content': post1
-    },
-    'hi.md': {
-      'content': post2
-    },
-    'ha.md': {
-      'content': post3
-    }
+    // 'hello.md': {
+    //   'content': post1
+    // },
+    // 'hi.md': {
+    //   'content': post2
+    // },
+    // 'ha.md': {
+    //   'content': post3
+    // }
   }
 }

--- a/packages/widget-reorder/src/control.tsx
+++ b/packages/widget-reorder/src/control.tsx
@@ -40,8 +40,8 @@ export const createControl: CreateControl = (options = {}) => {
 
       const currentOrder = value.toJS()
       const { newOrder, modified } = diff({
-        data: currentOrder,
-        currentOrder: data,
+        currentOrder,
+        data,
         key: fieldId,
       })
 

--- a/packages/widget-reorder/src/control.tsx
+++ b/packages/widget-reorder/src/control.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { fromJS, List } from 'immutable'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import { WidgetProps } from '@ncwidgets/common-typings'
-import { reorder, diff, extract, generateIdentifierFromField } from './utils'
+import { reorder, diff, extract, createWidgetId } from './utils'
 
 const defaultListItem = item => Object.values(item).join(' ')
 
@@ -54,7 +54,7 @@ export const createControl: CreateControl = (options = {}) => {
         onChange(fromJS(data))
       }
       this.setState({ data })
-      const key = generateIdentifierFromField(field)
+      const key = createWidgetId(field)
       localStorage.setItem(key, JSON.stringify(data))
     }
 

--- a/packages/widget-reorder/src/control.tsx
+++ b/packages/widget-reorder/src/control.tsx
@@ -112,6 +112,7 @@ export const createControl: CreateControl = (options = {}) => {
           {modified !== 'none' && <NoticeBar displayChange={this.handleDisplayChange}>
             {modifiedMsg[modified]}
           </NoticeBar>}
+          {modified === 'none' && Object.keys(normalizedData).length === 0 && <div>Source collection is empty</div>}
           {value && <Droppable droppableId="droppable">
             {(provided, snapshot) => (
               <div

--- a/packages/widget-reorder/src/index.ts
+++ b/packages/widget-reorder/src/index.ts
@@ -1,5 +1,5 @@
 import { createControl } from './control'
-import { Preview } from './preview'
+import { Preview, usePreviewData } from './preview'
 
 const Control = createControl()
 
@@ -14,4 +14,5 @@ export {
   Control,
   Preview,
   createControl,
+  usePreviewData,
 }

--- a/packages/widget-reorder/src/notice.tsx
+++ b/packages/widget-reorder/src/notice.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+
+const wrapperStyle: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  padding: '1rem 1rem 0 1rem',
+  boxSizing: 'border-box',
+  backgroundColor: '#dfdfe3',
+  borderTopRightRadius: '3px',
+  marginBottom: '-5px',
+}
+
+const style: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  padding: '0.25rem',
+  textAlign: 'center',
+  color: '#8C5708',
+  borderRadius: '3px',
+  lineHeight: '1.5',
+  backgroundColor: '#FFC23E',
+}
+
+
+export const NoticeBar = ({ children, displayChange }) => (
+  <div style={wrapperStyle}>
+    <div style={style}>
+      {children}
+      {' '}
+      <button onClick={() => displayChange()}>Show</button>
+    </div>
+  </div>
+)

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { generateIdentifierFromField, sortByOrder } from './utils'
+import { generateIdentifierFromField, copy } from './utils'
 
 export const Preview = (props) => {
   const [data, setData] = useState<Array<object>>([])
@@ -18,14 +18,14 @@ export const Preview = (props) => {
     
     const currentOrder = value.toJS()
     const key: string = props.field.get('id_field')
-    const { newOrder, modified } = sortByOrder({
-      currentOrder,
-      data,
+    const newOrder = copy({
+      from: data,
+      into: currentOrder,
       // @ts-ignore (how can we avoid this?)
       key
     })
 
-    if (modified) setData(newOrder)
+    setData(newOrder)
 
   }, [value])
 

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { createWidgetId } from './utils'
+import { List } from 'immutable'
+import { createWidgetId, extract } from './utils'
 
 export const Preview = ({ value, field }) => {
-  const [data, setData] = useState<object[]>([])
+  const [data, setData] = useState<Record<any, any>>({})
   const widgetId = useRef<string>(createWidgetId(field))
 
   const fieldId: string = field.get('id_field')
+  const fieldDisplay: List<string> = field.get('display_fields')
 
   // Fetch initial data from sessionStorage
   useEffect(() => {
@@ -13,16 +15,17 @@ export const Preview = ({ value, field }) => {
     if (normalizedData) setData(JSON.parse(normalizedData))
   }, [])
 
-  if (!data) return <div>Loading...</div>
+  if (Object.keys(data).length === 0) return <div>Loading...</div>
   return(
     <ul>
       {value.map((item, i) => {
         const sourceItem = data[item.get(fieldId)]
+        const displayData = extract(sourceItem, ...fieldDisplay)
         if (typeof sourceItem === 'undefined') return <li>Oh no</li>
         return (
           <li key={`listItem-${i}`}>
             <p>
-              {Object.entries(sourceItem).map(([key, value]) => `${key}: ${value}`).join(', ')}
+              {Object.values(displayData).join(' ')}
             </p>
           </li>
         )})}

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,43 +1,30 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { createWidgetId, copy } from './utils'
 
-export const Preview = (props) => {
+export const Preview = ({ value, field }) => {
   const [data, setData] = useState<object[]>([])
-  const { value, field } = props
+  const widgetId = useRef<string>(createWidgetId(field))
+
+  const fieldId: string = field.get('id_field')
 
   // Fetch initial data from localstorage
   useEffect(() => {
-    const key = createWidgetId(field)
-    const metadata = localStorage.getItem(key)
-    if (metadata) setData(JSON.parse(metadata))
+    const sourceData = localStorage.getItem(widgetId.current)
+    if (sourceData) setData(JSON.parse(sourceData))
   }, [])
-
-  // Reorder data when value changes
-  useEffect(() => {
-    if (data.length === 0) return
-    
-    const currentOrder = value.toJS()
-    const key: string = field.get('id_field')
-    const newOrder = copy({
-      from: data,
-      into: currentOrder,
-      // @ts-ignore (how can we avoid this?)
-      key
-    })
-
-    setData(newOrder)
-
-  }, [value])
 
   if (!data) return <div>Loading...</div>
   return(
     <ul>
-      {data.map((item, i) => (
-        <li key={`listItem-${i}`}>
-          <p>
-            {Object.entries(item).map(([key, value]) => `${key}: ${value}`).join(', ')}
-          </p>
-        </li>
-      ))}
+      {value.map((item, i) => {
+        const sourceItem = data.find(sourceItem => sourceItem[fieldId] === item.get(fieldId))
+        if (typeof sourceItem === 'undefined') return <li>Oh no</li>
+        return (
+          <li key={`listItem-${i}`}>
+            <p>
+              {Object.entries(sourceItem).map(([key, value]) => `${key}: ${value}`).join(', ')}
+            </p>
+          </li>
+        )})}
     </ul>)
 }

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -3,7 +3,7 @@ import { List } from 'immutable'
 import { createWidgetId, extract } from './utils'
 
 export const Preview = ({ value, field }) => {
-  const [data, setData] = useState<Record<any, any>>({})
+  const [data, setData] = useState<null | Record<any, any>>(null)
   const widgetId = useRef<string>(createWidgetId(field))
 
   const fieldId: string = field.get('id_field')
@@ -15,7 +15,7 @@ export const Preview = ({ value, field }) => {
     if (normalizedData) setData(JSON.parse(normalizedData))
   }, [])
 
-  if (Object.keys(data).length === 0) return <div>Loading...</div>
+  if (!data) return <div>Loading...</div>
   return(
     <ul>
       {value.map((item, i) => {

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { createWidgetId, copy } from './utils'
+import { createWidgetId } from './utils'
 
 export const Preview = ({ value, field }) => {
   const [data, setData] = useState<object[]>([])
@@ -7,17 +7,17 @@ export const Preview = ({ value, field }) => {
 
   const fieldId: string = field.get('id_field')
 
-  // Fetch initial data from localstorage
+  // Fetch initial data from sessionStorage
   useEffect(() => {
-    const sourceData = localStorage.getItem(widgetId.current)
-    if (sourceData) setData(JSON.parse(sourceData))
+    const normalizedData = sessionStorage.getItem(widgetId.current)
+    if (normalizedData) setData(JSON.parse(normalizedData))
   }, [])
 
   if (!data) return <div>Loading...</div>
   return(
     <ul>
       {value.map((item, i) => {
-        const sourceItem = data.find(sourceItem => sourceItem[fieldId] === item.get(fieldId))
+        const sourceItem = data[item.get(fieldId)]
         if (typeof sourceItem === 'undefined') return <li>Oh no</li>
         return (
           <li key={`listItem-${i}`}>

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,11 +1,43 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { generateIdentifierFromField, sortByOrder } from './utils'
 
-export const Preview = ({ value }) => (
+export const Preview = (props) => {
+  const [data, setData] = useState<Array<object>>([])
+  const { value } = props
+
+  // Fetch initial data from localstorage
+  useEffect(() => {
+    const key = generateIdentifierFromField(props.field)
+    const metadata = localStorage.getItem(key)
+    if (metadata) setData(JSON.parse(metadata))
+  }, [])
+
+  // Reorder data when value changes
+  useEffect(() => {
+    if (data.length === 0) return
+    
+    const currentOrder = value.toJS()
+    const key: string = props.field.get('id_field')
+    const { newOrder, modified } = sortByOrder({
+      currentOrder,
+      data,
+      // @ts-ignore (how can we avoid this?)
+      key
+    })
+
+    if (modified) setData(newOrder)
+
+  }, [value])
+
+  if (!data) return <div>Loading...</div>
+  return(
   <ul>
-    {value.map(item => (
-      <li key={item.get('id')}>
-        {item.get('title')}
-      </li>
+    {data.map((item, i) => (
+      <li key={`listItem-${i}`}>
+        <p>
+          {Object.entries(item).map(([key, value]) => `${key}: ${value}`).join(', ')}
+        </p>
+    </li>
     ))}
-  </ul>
-)
+  </ul>)
+}

--- a/packages/widget-reorder/src/preview.tsx
+++ b/packages/widget-reorder/src/preview.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react'
-import { generateIdentifierFromField, copy } from './utils'
+import { createWidgetId, copy } from './utils'
 
 export const Preview = (props) => {
-  const [data, setData] = useState<Array<object>>([])
-  const { value } = props
+  const [data, setData] = useState<object[]>([])
+  const { value, field } = props
 
   // Fetch initial data from localstorage
   useEffect(() => {
-    const key = generateIdentifierFromField(props.field)
+    const key = createWidgetId(field)
     const metadata = localStorage.getItem(key)
     if (metadata) setData(JSON.parse(metadata))
   }, [])
@@ -17,7 +17,7 @@ export const Preview = (props) => {
     if (data.length === 0) return
     
     const currentOrder = value.toJS()
-    const key: string = props.field.get('id_field')
+    const key: string = field.get('id_field')
     const newOrder = copy({
       from: data,
       into: currentOrder,
@@ -31,13 +31,13 @@ export const Preview = (props) => {
 
   if (!data) return <div>Loading...</div>
   return(
-  <ul>
-    {data.map((item, i) => (
-      <li key={`listItem-${i}`}>
-        <p>
-          {Object.entries(item).map(([key, value]) => `${key}: ${value}`).join(', ')}
-        </p>
-    </li>
-    ))}
-  </ul>)
+    <ul>
+      {data.map((item, i) => (
+        <li key={`listItem-${i}`}>
+          <p>
+            {Object.entries(item).map(([key, value]) => `${key}: ${value}`).join(', ')}
+          </p>
+        </li>
+      ))}
+    </ul>)
 }

--- a/packages/widget-reorder/src/renderListItem.ts
+++ b/packages/widget-reorder/src/renderListItem.ts
@@ -1,0 +1,18 @@
+import { List } from 'immutable'
+import { extract } from './utils'
+
+interface RenderListItemArgs {
+  item: Record<any, any>;
+  fieldDisplay: List<string>;
+  isRemoved: boolean;
+}
+type RenderListResult = string | React.ComponentType<RenderListItemArgs>;
+export type RenderListItem = (args: RenderListItemArgs) => RenderListResult
+
+export const defaultListItem: RenderListItem = ({ item, fieldDisplay, isRemoved }) => {
+  if (isRemoved) {
+    return `This item has been removed (id: ${item})`
+  }
+  const displayData = extract(item, ...fieldDisplay)
+  return Object.values(displayData).join(' ')
+}

--- a/packages/widget-reorder/src/utils.test.ts
+++ b/packages/widget-reorder/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { removeOutdatedItem, diff, extract, copy } from './utils'
+import { removeOutdatedItem, diff, extract, normalize } from './utils'
 
 describe('removeOutdatedItem', () => {
   it('should remove outdated items', () => {
@@ -17,21 +17,6 @@ describe('diff', () => {
     const currentOrder = [{ id: 1 }, { id: 2 }, { id: 3 }]
     const data = [{ id: 2 }, { id: 3 }, { id: 4 }]
     const expected = [{ id: 2 }, { id: 3 }, { id: 4 }]
-
-    const result = diff({
-      currentOrder,
-      data,
-      key: 'id',
-    })
-
-    expect(result.modified).toBe(true)
-    expect(result.newOrder).toEqual(expected)
-  })
-
-  it('should put id 3 at the end and merge', () => {
-    const currentOrder = [{ id: 1 }, { id: 2 }]
-    const data = [{ id: 3, title: 'title3' }, { id: 1, title: 'title1' }, { id: 2, title: 'title2' }]
-    const expected = [{ id: 1, title: 'title1' }, { id: 2, title: 'title2' }, { id: 3, title: 'title3' }]
 
     const result = diff({
       currentOrder,
@@ -87,14 +72,17 @@ describe('extract', () => {
   })
 })
 
-describe('copy', () => {
-  it('should copy from data into order by matching key', () => {
-    const order = [{ id: 1 }, { id: 4 }, { id: 3 }]
-    const data = [{ id: 1, a: 'a1' }, { id: 2, a: 'a2' }, { id: 3, a: 'a3' }, { id: 4, a: 'a4' }]
+describe('normalize', () => {
+  it('should turn an array of T to an object of a key of T', () => {
+    const data = [ {id: 'a', content: 100}, {id: 'b', content: 200}, {id: 'c', content: 300} ]
+    const expected = {
+      a: data[0],
+      b: data[1],
+      c: data[2],
+    }
+    const result = normalize(data, 'id')
 
-    const expected = [{ id: 1, a: 'a1'}, { id: 4, a: 'a4' }, { id: 3, a: 'a3' }]
-
-    const result = copy({ from: data, into: order, key: 'id' })
     expect(result).toEqual(expected)
+    expect(result.a).toBe(data[0])
   })
 })

--- a/packages/widget-reorder/src/utils.test.ts
+++ b/packages/widget-reorder/src/utils.test.ts
@@ -28,6 +28,22 @@ describe('diff', () => {
     expect(result.newOrder).toEqual(expected)
   })
 
+  // Or sparate them as two functions?
+  // it('should put id 3 at the end and merge', () => {
+  //   const currentOrder = [{ id: 1 }, { id: 2 }]
+  //   const data = [{ id: 3, title: 'title3' }, { id: 1, title: 'title1' }, { id: 2, title: 'title2' }]
+  //   const expected = [{ id: 1, title: 'title1' }, { id: 2, title: 'title2' }, { id: 3, title: 'title3' }]
+
+  //   const result = diff({
+  //     currentOrder,
+  //     data,
+  //     key: 'id',
+  //   })
+
+  //   expect(result.modified).toBe(true)
+  //   expect(result.newOrder).toEqual(expected)
+  // })
+
   it('should return the same array if nothing changed', () => {
     const currentOrder = [{ id: 1 }, { id: 2 }, { id: 3 }]
     const data = [...currentOrder]

--- a/packages/widget-reorder/src/utils.test.ts
+++ b/packages/widget-reorder/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { removeOutdatedItem, diff, extract } from './utils'
+import { removeOutdatedItem, diff, extract, copy } from './utils'
 
 describe('removeOutdatedItem', () => {
   it('should remove outdated items', () => {
@@ -28,21 +28,20 @@ describe('diff', () => {
     expect(result.newOrder).toEqual(expected)
   })
 
-  // Or sparate them as two functions?
-  // it('should put id 3 at the end and merge', () => {
-  //   const currentOrder = [{ id: 1 }, { id: 2 }]
-  //   const data = [{ id: 3, title: 'title3' }, { id: 1, title: 'title1' }, { id: 2, title: 'title2' }]
-  //   const expected = [{ id: 1, title: 'title1' }, { id: 2, title: 'title2' }, { id: 3, title: 'title3' }]
+  it('should put id 3 at the end and merge', () => {
+    const currentOrder = [{ id: 1 }, { id: 2 }]
+    const data = [{ id: 3, title: 'title3' }, { id: 1, title: 'title1' }, { id: 2, title: 'title2' }]
+    const expected = [{ id: 1, title: 'title1' }, { id: 2, title: 'title2' }, { id: 3, title: 'title3' }]
 
-  //   const result = diff({
-  //     currentOrder,
-  //     data,
-  //     key: 'id',
-  //   })
+    const result = diff({
+      currentOrder,
+      data,
+      key: 'id',
+    })
 
-  //   expect(result.modified).toBe(true)
-  //   expect(result.newOrder).toEqual(expected)
-  // })
+    expect(result.modified).toBe(true)
+    expect(result.newOrder).toEqual(expected)
+  })
 
   it('should return the same array if nothing changed', () => {
     const currentOrder = [{ id: 1 }, { id: 2 }, { id: 3 }]
@@ -84,6 +83,18 @@ describe('extract', () => {
     }
     const result = extract(data, 'a', 'b')
 
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('copy', () => {
+  it('should copy from data into order by matching key', () => {
+    const order = [{ id: 1 }, { id: 4 }, { id: 3 }]
+    const data = [{ id: 1, a: 'a1' }, { id: 2, a: 'a2' }, { id: 3, a: 'a3' }, { id: 4, a: 'a4' }]
+
+    const expected = [{ id: 1, a: 'a1'}, { id: 4, a: 'a4' }, { id: 3, a: 'a3' }]
+
+    const result = copy({ from: data, into: order, key: 'id' })
     expect(result).toEqual(expected)
   })
 })

--- a/packages/widget-reorder/src/utils.ts
+++ b/packages/widget-reorder/src/utils.ts
@@ -27,45 +27,39 @@ interface DiffResult<T> {
   newOrder: T[];
 }
 
-interface CopyArgs<T> {
-  from: T[];
-  into: T[];
-  key: keyof T;
-}
-
-export const copy = <T>({from, into, key}: CopyArgs<T>): T[] => {
-  return into.map(a => ({
-    ...a,
-    ...from.find(b => b[key] === a[key])
-  }))
-}
-
 export const diff = <T>({
   currentOrder,
   data,
   key,
 }: DiffArgs<T>): DiffResult<T> => {
-  const currentOrderMerged = copy({ from: data, into: currentOrder, key })
-  const outdatedItem = differenceBy(currentOrderMerged, data, key)
-  const newItem = differenceBy(data, currentOrderMerged, key)
+  const outdatedItem = differenceBy(currentOrder, data, key)
+  const newItem = differenceBy(data, currentOrder, key)
   if (outdatedItem.length === 0 && newItem.length === 0) {
     return {
       modified: false,
-      newOrder: currentOrderMerged
+      newOrder: currentOrder,
     }
   }
 
-  const newOrder = removeOutdatedItem(currentOrderMerged, outdatedItem, key).concat(
+  const newOrder = removeOutdatedItem(currentOrder, outdatedItem, key).concat(
     newItem
   )
   return {
     modified: true,
-    newOrder
+    newOrder,
   }
 }
 
-export const reorder = (list, startIndex, endIndex) => {
-  const result = Array.from(list)
+
+export const normalize = <T, K extends keyof T>(data: T[], key: K): Record<string, T> => 
+  data.reduce((result, item) => {
+    const id = String(item[key])
+    result[id] = item
+    return result
+  }, ({} as Record<string, T>))
+
+export const reorder = ({ data, startIndex, endIndex }) => {
+  const result = Array.from(data)
   const [removed] = result.splice(startIndex, 1)
   result.splice(endIndex, 0, removed)
 

--- a/packages/widget-reorder/src/utils.ts
+++ b/packages/widget-reorder/src/utils.ts
@@ -1,7 +1,4 @@
 import differenceBy = require('lodash/differenceBy')
-import intersectionWith = require('lodash/intersectionWith')
-import assign = require('lodash/assign')
-import isEqual = require('lodash/isEqual')
 
 export const extract = <T, K extends keyof T>(object: T, ...keys: K[]): Pick<T, K> =>
   keys.reduce((result, key) => {
@@ -29,26 +26,40 @@ interface DiffResult<T> {
   newOrder: T[];
 }
 
+interface CopyArgs<T> {
+  from: T[]
+  into: T[]
+  key: keyof T
+}
+
+export const copy = <T>({from, into, key}: CopyArgs<T>): T[] => {
+  return into.map(a => ({
+    ...a,
+    ...from.find(b => b[key] === a[key])
+  }))
+}
+
 export const diff = <T>({
   currentOrder,
   data,
   key,
 }: DiffArgs<T>): DiffResult<T> => {
-  const outdatedItem = differenceBy(currentOrder, data, key)
-  const newItem = differenceBy(data, currentOrder, key)
+  const currentOrderMerged = copy({ from: data, into: currentOrder, key })
+  const outdatedItem = differenceBy(currentOrderMerged, data, key)
+  const newItem = differenceBy(data, currentOrderMerged, key)
   if (outdatedItem.length === 0 && newItem.length === 0) {
     return {
       modified: false,
-      newOrder: currentOrder,
+      newOrder: currentOrderMerged
     }
   }
 
-  const newOrder = removeOutdatedItem(currentOrder, outdatedItem, key).concat(
+  const newOrder = removeOutdatedItem(currentOrderMerged, outdatedItem, key).concat(
     newItem
   )
   return {
     modified: true,
-    newOrder,
+    newOrder
   }
 }
 
@@ -58,19 +69,6 @@ export const reorder = (list, startIndex, endIndex) => {
   result.splice(endIndex, 0, removed)
 
   return result
-}
-
-// Not sure about this one...
-export const sortByOrder = <T>({ currentOrder, data, key }: DiffArgs<T>): T[] => {
-  if (currentOrder.length <= 0 && data.length <= 0) return []
-  // @ts-ignore or this one
-  const newOrder = intersectionWith(currentOrder, data, (a, b) => a[key] === b[key] && assign(a, b))
-  const modified = !isEqual(newOrder, data)
-  return {
-    // @ts-ignore or this one
-    newOrder,
-    modified
-  }
 }
 
 export const generateIdentifierFromField = (field) => {

--- a/packages/widget-reorder/src/utils.ts
+++ b/packages/widget-reorder/src/utils.ts
@@ -1,4 +1,7 @@
 import differenceBy = require('lodash/differenceBy')
+import intersectionWith = require('lodash/intersectionWith')
+import assign = require('lodash/assign')
+import isEqual = require('lodash/isEqual')
 
 export const extract = <T, K extends keyof T>(object: T, ...keys: K[]): Pick<T, K> =>
   keys.reduce((result, key) => {
@@ -55,4 +58,21 @@ export const reorder = (list, startIndex, endIndex) => {
   result.splice(endIndex, 0, removed)
 
   return result
+}
+
+// Not sure about this one...
+export const sortByOrder = <T>({ currentOrder, data, key }: DiffArgs<T>): T[] => {
+  if (currentOrder.length <= 0 && data.length <= 0) return []
+  // @ts-ignore or this one
+  const newOrder = intersectionWith(currentOrder, data, (a, b) => a[key] === b[key] && assign(a, b))
+  const modified = !isEqual(newOrder, data)
+  return {
+    // @ts-ignore or this one
+    newOrder,
+    modified
+  }
+}
+
+export const generateIdentifierFromField = (field) => {
+  return `${field.get('collection')}-${field.get('name')}-meta`
 }

--- a/packages/widget-reorder/src/utils.ts
+++ b/packages/widget-reorder/src/utils.ts
@@ -1,3 +1,4 @@
+import { Map } from 'immutable'
 import differenceBy = require('lodash/differenceBy')
 
 export const extract = <T, K extends keyof T>(object: T, ...keys: K[]): Pick<T, K> =>
@@ -27,9 +28,9 @@ interface DiffResult<T> {
 }
 
 interface CopyArgs<T> {
-  from: T[]
-  into: T[]
-  key: keyof T
+  from: T[];
+  into: T[];
+  key: keyof T;
 }
 
 export const copy = <T>({from, into, key}: CopyArgs<T>): T[] => {
@@ -71,6 +72,6 @@ export const reorder = (list, startIndex, endIndex) => {
   return result
 }
 
-export const generateIdentifierFromField = (field) => {
+export const createWidgetId = (field: Map<unknown, unknown>) => {
   return `${field.get('collection')}-${field.get('name')}-meta`
 }


### PR DESCRIPTION
#### Summary
This will adress "handle the case where display fields are out of date" in issue #3. The idea is to store only the ID's of the referenced collection and query data that is displayed from that collection. In order to pass the queried data to preview without calling `onChange` (to avoid triggering unsaved changes if there are none) we use local storage, kind of hacky but it works for now.

So basically we store `ID`s from the referenced collection :arrow_right: control mounts :arrow_right: query fresh data :arrow_right: save to local storage :arrow_right: preview mounts :arrow_right: fetch from local storage. And then reorder the queried items when `onChange` is called as previously. 

Things added:
* `generateIdentifierFromField` to generate a unique key for local storage 
* ~~`sortByOrder` sorts and merges incoming values with collection-data (not sure about this one, will probably change)~~ replaced with `copy({from, into, key})` which is used to copy fields from fetched data into the ordered array of `id_field`'s

Things to fix:
* ~~Draggable list is not synced when component mounts (needs to merge id-array with data-array inside or after `diff`(?))~~ [done]
*  Abstract data handling from user in preview (expose a `getData()` function, HOC or custom hook?)
* Preview mounts before data is saved in local storage

Questions:
* Should we clear local storage when control unmount?

#### Other minor stuff
* Removed `id_field` to be rendered in control if its not in `display_fields`