### PR TITLE
feat(id): allow hidden option

### DIFF
--- a/packages/playground/static/config.yml
+++ b/packages/playground/static/config.yml
@@ -19,7 +19,7 @@ collections:
         widget: ncw-id
         prefix: post
         timestamp: true
-        hint: This widget generate a unique read-only id
+        hint: This widget generates a unique read-only id
 
       - label: Coffee
         name: coffee

--- a/packages/widget-id/readme.md
+++ b/packages/widget-id/readme.md
@@ -1,0 +1,63 @@
+<h1 align="center">ID Widget for NetlifyCMS</h1>
+
+<p align="center">A widget for <a href="https://www.netlifycms.org/" target="_blank">netlify-cms</a> to generate ID for items in a list, or entries of a folder collection.</p>
+
+---
+
+<p align="center">⚠ Unstable: Under active development</p>
+
+## Installation
+```
+npm i @ncwidgets/id
+```
+
+---
+
+## Demo
+
+In the demo below, the `categories` field is loaded from a file collection.
+
+<a href="https://custom-widgets.netlify.com/#/collections/posts/entries/hej" target="_blank">Live demo</a>
+
+### Register
+```js
+import cms from 'netlify-cms-app'
+import { Widget as IdWidget } from '@ncwidgets/id'
+
+cms.registerWidget(IdWidget)
+
+cms.init()
+```
+
+## How to use
+### Example config
+
+```yml
+collections:
+  - label: Posts
+    label_singular: Post
+    name: posts
+    folder: _posts
+    create: true
+    fields:
+      - label: ID
+        name: id
+
+        # Default widget name
+        widget: ncw-id
+        
+        # <Optional> If specified, add a prefix, i.e post-dnfuHvOhP
+        prefix: post
+
+        # <Optional> If `true`, add timestamp, i.e post-1588747959991-dnfuHvOhP
+        # This can be used to sort collection by creation time
+        timestamp: false
+
+        # <Optional> Hide the widget from UI
+        # Beware: We literally add `display: none` to the DOM node wrapping the input. It will break if netlifyCMS's editor pane structure changes.
+        hidden: false
+```
+
+## Contribute
+
+Found a bug or a missing feature? Please feel free to send over a PR, or open an issue with the `bug` or `enhancement` tag.

--- a/packages/widget-id/src/control.tsx
+++ b/packages/widget-id/src/control.tsx
@@ -3,12 +3,24 @@ import shortid from 'shortid'
 import { WidgetProps } from '@ncwidgets/common-typings'
 
 export class Control extends React.Component<WidgetProps> {
+  public inputRef: React.RefObject<HTMLInputElement>
   public constructor(props: WidgetProps) {
     super(props)
+    this.inputRef = React.createRef()
 
     if (props.value) return
 
     this.generateId()
+  }
+
+  public componentDidMount() {
+    const { field } = this.props
+    if (!field.get('hidden')) return
+    const $input = this.inputRef.current
+    if (!$input) return
+    const $container = $input.parentElement
+    if (!$container) return
+    $container.style.display = 'none'
   }
 
   public generateId() {


### PR DESCRIPTION
close #38 

It's not possible to hide a widget completely, as it doesn't control the styling of its label & its wrapper.

This is a hack: I'm literally accessing the widget's parent DOM node on mount & adding `display: none` to it. It'll definitely break if NetlifyCMS's control pane's structure changes. Also, it's just not good practice!

However.. (a) this is a much desirable feature and (b) this widget has always meant to be an in-between solution while NetlifyCMS comes up with its own ID solution, so I think it's reasonable to allow users to opt-in via `hidden: true` with a warning.